### PR TITLE
Add button group styles to style.css

### DIFF
--- a/app/static/css/style.css
+++ b/app/static/css/style.css
@@ -390,3 +390,15 @@ body {
     z-index: 1000;
     pointer-events: none;
 }
+
+/* Button Group Styles */
+.button-group {
+    display: flex;
+    align-items: center; 
+    gap: 10px; 
+    margin-bottom: 20px; 
+}
+
+#major-select {
+    flex-grow: 1; 
+}


### PR DESCRIPTION
 Adjusted CSS to ensure "Generate Plan", "AI Validate Plan", and "Export PDF" buttons are displayed in the same row.
previous:
<img width="678" height="126" alt="Screenshot 2025-09-24 at 10 31 04" src="https://github.com/user-attachments/assets/8fdbb193-732c-4af6-86e5-b991ac06b9ec" />
now:
<img width="729" height="127" alt="Screenshot 2025-09-24 at 10 51 56" src="https://github.com/user-attachments/assets/f04b2ae0-130c-4abb-b139-4cf56150b096" />
