### PR TITLE
fix: keep unit cards in single-line flex layout after search reset

### DIFF
--- a/app/static/css/style.css
+++ b/app/static/css/style.css
@@ -304,7 +304,7 @@ body {
 }
 
 .unit-card.hidden {
-    display: none;
+     display: none !important;
 }
 
 /* Plan Summary */

--- a/app/static/css/style.css
+++ b/app/static/css/style.css
@@ -304,7 +304,7 @@ body {
 }
 
 .unit-card.hidden {
-     display: none !important;
+    display: none !important;
 }
 
 /* Plan Summary */

--- a/app/static/js/app.js
+++ b/app/static/js/app.js
@@ -725,7 +725,7 @@ function updateAvailableUnitsFilter() {
     $('#available-units .unit-card').each(function() {
         const unitCode = $(this).data('unit-code');
         if (unitsInPlan.has(unitCode)) {
-            $(this).addClass('hidden');    
+            $(this).addClass('hidden');
         } else {
             $(this).removeClass('hidden');  
             $(this).css('display', '');     
@@ -749,9 +749,9 @@ function updateSectionHeaders() {
         });
 
         if (hasVisibleUnits) {
-            $header.show();   
+            $header.show();
         } else {
-            $header.hide();  
+            $header.hide();
         }
     });
 }
@@ -777,9 +777,9 @@ function filterUnits(searchTerm) {
         const notInPlan = !unitsInPlan.has(actualUnitCode);
 
         if (matchesSearch && notInPlan) {
-            $(this).removeClass('hidden').css('display', '');  // inline 제거
+            $(this).removeClass('hidden').css('display', '');  
         } else {
-            $(this).addClass('hidden');;
+            $(this).addClass('hidden');
         }
     });
 

--- a/app/static/js/app.js
+++ b/app/static/js/app.js
@@ -777,7 +777,7 @@ function filterUnits(searchTerm) {
         const notInPlan = !unitsInPlan.has(actualUnitCode);
 
         if (matchesSearch && notInPlan) {
-            $(this).removeClass('hidden').css('display', '');  
+            $(this).removeClass('hidden').css('display', '');
         } else {
             $(this).addClass('hidden');
         }

--- a/app/static/js/app.js
+++ b/app/static/js/app.js
@@ -40,7 +40,8 @@ function setupEventHandlers() {
 
     // Unit search
     $('#unit-search').on('input', function() {
-        filterUnits($(this).val());
+        if (!this.value) { $('#available-units .unit-card').css('display',''); }
+        filterUnits(this.value);
     });
 }
 
@@ -724,9 +725,10 @@ function updateAvailableUnitsFilter() {
     $('#available-units .unit-card').each(function() {
         const unitCode = $(this).data('unit-code');
         if (unitsInPlan.has(unitCode)) {
-            $(this).hide();
+            $(this).addClass('hidden');    
         } else {
-            $(this).show();
+            $(this).removeClass('hidden');  
+            $(this).css('display', '');     
         }
     });
 
@@ -739,21 +741,21 @@ function updateSectionHeaders() {
         const $header = $(this);
         let hasVisibleUnits = false;
 
-        // Check if any unit cards after this header are visible
-        $header.nextUntil('.unit-section-header, :last').each(function() {
-            if ($(this).hasClass('unit-card') && $(this).is(':visible')) {
+                $header.nextUntil('.unit-section-header').each(function() {
+            if ($(this).hasClass('unit-card') && !$(this).hasClass('hidden')) {
                 hasVisibleUnits = true;
                 return false; // break
             }
         });
 
         if (hasVisibleUnits) {
-            $header.show();
+            $header.show();   
         } else {
-            $header.hide();
+            $header.hide();  
         }
     });
 }
+
 
 function filterUnits(searchTerm) {
     const term = searchTerm.toLowerCase();
@@ -775,9 +777,9 @@ function filterUnits(searchTerm) {
         const notInPlan = !unitsInPlan.has(actualUnitCode);
 
         if (matchesSearch && notInPlan) {
-            $(this).show().removeClass('hidden');
+            $(this).removeClass('hidden').css('display', '');  // inline 제거
         } else {
-            $(this).hide().addClass('hidden');
+            $(this).addClass('hidden');;
         }
     });
 


### PR DESCRIPTION
- Ensure unit cards maintain consistent flex layout after clearing search input

[before]
<img width="1248" height="532" alt="스크린샷 2025-09-25 061946" src="https://github.com/user-attachments/assets/643360c4-a435-4eb8-911b-e0cb984f38d9" />

[after]
<img width="1270" height="457" alt="after" src="https://github.com/user-attachments/assets/8db1a3e9-9e1f-460c-9393-e0d3526f14c8" />

