### PR TITLE
Upgrade: plan validation so all errors and warnings are shown when adding and removing units

### DIFF
--- a/app/controller.py
+++ b/app/controller.py
@@ -906,43 +906,49 @@ def validate_plan_programmatically(plan_data):
     for semester, units in plan_data.items():
         if len(units) > 4:
             critical_errors.append(f"{semester} has {len(units)} units, but maximum allowed is 4.")
-        elif len(units) < 4 and len(units) > 0:
+        elif 0 < len(units) < 4:
             warnings.append(f"{semester} has {len(units)} units, target is 4 units.")
 
     # Rule 3: Maximum 12 Level 1 units - always critical error if exceeded
     if level_1_count > 12:
         critical_errors.append(f"There are {level_1_count} Level 1 units which exceeds the maximum of 12.")
 
-    # Rule 4: Minimum 12 Level 2 or Level 3 units - warn if close, error if far off
+    # Rule 4: Minimum 12 Level 2 or Level 3 units
     if level_2_3_count < 8:  # Really low
         critical_errors.append(f"There are only {level_2_3_count} Level 2 or Level 3 units, minimum required is 12.")
     elif level_2_3_count < 12:
         warnings.append(f"There are only {level_2_3_count} Level 2 or Level 3 units, minimum required is 12.")
 
-    # Rule 5: Minimum 6 Level 3 units - warn if close, error if very low
+    # Rule 5: Minimum 6 Level 3 units
     if level_3_count < 3:
         critical_errors.append(f"There are only {level_3_count} Level 3 units, minimum required is 6.")
     elif level_3_count < 6:
         warnings.append(f"There are only {level_3_count} Level 3 units, minimum required is 6.")
 
-    # Return validation result
+    # Return validation result (🔸배열 포함)
     if critical_errors:
         return {
             'isValid': False,
-            'reason': f"Critical issues found: {' '.join(critical_errors)}",
-            'type': 'error'
+            'reason': "Critical issues found: " + " ".join(critical_errors),
+            'type': 'error',
+            'errors': critical_errors,   # ← 모든 에러를 배열로
+            'warnings': warnings,        # ← 경고도 함께 반환
         }
     elif warnings:
         return {
             'isValid': True,  # Valid but incomplete
-            'reason': f"Plan incomplete: {warnings[0]}",  # Show first warning
-            'type': 'warning'
+            'reason': "Plan incomplete: " + warnings[0],  # 기존 호환(첫 문장)
+            'type': 'warning',
+            'errors': [],                  # 배열 키는 항상 존재
+            'warnings': warnings,
         }
     else:
         return {
             'isValid': True,
             'reason': 'Plan meets all UWA degree requirements',
-            'type': 'success'
+            'type': 'success',
+            'errors': [],
+            'warnings': [],
         }
 
 def create_validation_prompt(major, plan_data):

--- a/app/static/css/style.css
+++ b/app/static/css/style.css
@@ -304,7 +304,7 @@ body {
 }
 
 .unit-card.hidden {
-    display: none;
+     display: none !important;
 }
 
 /* Plan Summary */

--- a/app/static/css/style.css
+++ b/app/static/css/style.css
@@ -12,7 +12,7 @@ body {
 /* Study Plan Grid */
 .semester-container {
     margin-bottom: 20px;
-    border: 1px solid #6c757d;
+    border: 1px solid #dc3545;
     border-radius: 8px;
     background: white;
 }
@@ -257,7 +257,7 @@ body {
 
 /* Semester Capacity Indicator */
 .semester-full {
-    border-color: #dc3545 !important;
+    border-color: #28a745;
 }
 
 .semester-full .drop-zone {

--- a/app/static/css/style.css
+++ b/app/static/css/style.css
@@ -103,6 +103,10 @@ body {
     padding: 10px;
 }
 
+/* listing validation erros */
+#validation-status .validation-list { margin: 6px 0 0 18px; }
+
+
 /* Unit Section Headers */
 .unit-section-header {
     margin-top: 15px;

--- a/app/static/js/app.js
+++ b/app/static/js/app.js
@@ -254,30 +254,19 @@ function createUnitCard(unitCode, unitData = null) {
 
 function handleUnitMove(evt) {
     const semester = evt.to.dataset.semester;
-    const unitCount = $(evt.to).find('.unit-card').length;
     const unitCode = $(evt.item).data('unit-code');
 
-    // Always update the UI, but validate afterwards
+    // Always update the UI
     updateDropZone(evt.to);
     updateAvailableUnitsFilter();
 
-    // Check for validation issues and update status
-    if (unitCount > 4) {
-        updateValidationStatus(`${semester} has ${unitCount} units (max 4 allowed)`, 'error');
-    } else {
-        // Check prerequisite and semester availability constraints
-        const constraintValidation = validateUnitConstraints(unitCode, semester);
-        if (!constraintValidation.isValid) {
-            updateValidationStatus(constraintValidation.message, constraintValidation.type);
-        } else {
-            // Check other validation rules
-            validatePlan();
-        }
-    }
+    // Re-examine entire plan → Output all cumulative errors/warnings
+    validatePlan();
 
     // Apply visual validation to all units in the plan
     validateAndHighlightAllUnits();
 }
+
 
 function updateDropZone(semesterElement) {
     const unitCount = $(semesterElement).find('.unit-card').length;
@@ -306,41 +295,52 @@ function updateAllDropZones() {
 }
 
 function validatePlan() {
-    // First do local validation for immediate feedback
-    const localValidation = validatePlanLocally();
-
-    if (!localValidation.isValid) {
-        updateValidationStatus(localValidation.reason, localValidation.type);
-        return;
-    }
-
-    // If local validation passes, check with backend
     const plan = getCurrentPlan();
 
     $.ajax({
         url: '/api/validate_plan',
         method: 'POST',
         contentType: 'application/json',
-        data: JSON.stringify({ plan: plan }),
+        data: JSON.stringify({ plan }),
         success: function(data) {
-            // Use the type from backend if provided, otherwise default logic
-            const statusType = data.type || (data.isValid ? 'success' : 'error');
-            updateValidationStatus(data.reason, statusType);
-            logDebug('Validation result', data);
+            const issues = Array.isArray(data.errors) ? data.errors.slice() : [];
+            const warns  = Array.isArray(data.warnings) ? data.warnings.slice() : [];
+
+            // Compatibility handling in case the server sends only the reason without an array
+            if (!issues.length && data && typeof data.reason === 'string' && data.type === 'error') {
+                issues.push(data.reason);
+            }
+            if (!warns.length && data && typeof data.reason === 'string' && data.type === 'warning') {
+                warns.push(data.reason);
+            }
+
+            // Remove duplicates
+            const uniq = arr => [...new Set(arr)];
+
+            const allIssues = uniq(issues);
+            const allWarns  = uniq(warns);
+
+            if (allIssues.length) {
+                updateValidationStatus(allIssues, 'error');    
+            } else if (allWarns.length) {
+                updateValidationStatus(allWarns, 'warning');   
+            } else {
+                updateValidationStatus('Plan generated successfully', 'success');
+            }
         },
-        error: function(xhr) {
-            updateValidationStatus('Validation failed', 'error');
+        error: function() {
+            updateValidationStatus('Validation failed due to a network/server error.', 'error');
         }
     });
 }
 
-function validatePlanLocally() {
+function validatePlanLocally(asArray = false) {
     const issues = [];
     const warnings = [];
 
-    // Check semester capacity (max 4 units per semester)
+    // Limit of 4 courses per semester
     $('.semester-units').each(function() {
-        const semesterName = $(this).attr('id');
+        const semesterName = $(this).attr('id');   
         const unitCount = $(this).find('.unit-card').length;
 
         if (unitCount > 4) {
@@ -350,7 +350,7 @@ function validatePlanLocally() {
         }
     });
 
-    // Count total units
+    // Total number of units
     const totalUnits = $('.semester-units .unit-card').length;
     if (totalUnits > 24) {
         issues.push(`Total ${totalUnits} units exceeds maximum of 24`);
@@ -358,27 +358,25 @@ function validatePlanLocally() {
         warnings.push(`Plan has ${totalUnits} units (target: 24)`);
     }
 
-    // Return results
-    if (issues.length > 0) {
+    if (asArray) {
         return {
-            isValid: false,
-            reason: issues[0], // Show first critical issue
-            type: 'error'
-        };
-    } else if (warnings.length > 0) {
-        return {
-            isValid: true, // Valid but with warnings
-            reason: warnings[0] + ' - plan incomplete',
-            type: 'warning'
-        };
-    } else {
-        return {
-            isValid: true,
-            reason: 'Plan structure looks good',
-            type: 'success'
+            isValid: issues.length === 0,
+            type: issues.length ? 'error' : (warnings.length ? 'warning' : 'success'),
+            errors: issues,
+            warnings: warnings
         };
     }
+
+    // (For existing compatibility) Single-line mode
+    if (issues.length > 0) {
+        return { isValid: false, reason: issues[0], type: 'error' };
+    } else if (warnings.length > 0) {
+        return { isValid: true, reason: warnings[0] + ' - plan incomplete', type: 'warning' };
+    } else {
+        return { isValid: true, reason: 'Plan structure looks good', type: 'success' };
+    }
 }
+
 
 function validateUnitConstraints(unitCode, targetSemester) {
     // Find unit data in all units (both in plan and available)
@@ -787,24 +785,27 @@ function filterUnits(searchTerm) {
     updateSectionHeaders();
 }
 
-function updateValidationStatus(message, type) {
-    const statusDiv = $('#validation-status');
-    statusDiv.removeClass('validation-success validation-error validation-warning');
+function updateValidationStatus(messageOrList, type) {
+    const $box = $('#validation-status');
+    $box.removeClass('validation-success validation-error validation-warning');
 
-    switch(type) {
-        case 'success':
-            statusDiv.addClass('validation-success');
-            break;
-        case 'error':
-            statusDiv.addClass('validation-error');
-            break;
-        case 'warning':
-            statusDiv.addClass('validation-warning');
-            break;
+    if (type === 'error') $box.addClass('validation-error');
+    else if (type === 'warning') $box.addClass('validation-warning');
+    else $box.addClass('validation-success');
+
+    const title = type ? type[0].toUpperCase() + type.slice(1) : 'Status';
+    let body = '';
+
+    if (Array.isArray(messageOrList)) {
+        body = '<ul class="validation-list">' +
+               messageOrList.map(m => `<li>${m}</li>`).join('') +
+               '</ul>';
+    } else {
+        body = String(messageOrList || '');
     }
-
-    statusDiv.html(`<strong>${type.charAt(0).toUpperCase() + type.slice(1)}:</strong> ${message}`);
+    $box.html(`<strong>${title}:</strong> ${body}`);
 }
+
 
 function exportToPDF() {
     const plan = getCurrentPlan();

--- a/app/static/js/app.js
+++ b/app/static/js/app.js
@@ -40,7 +40,8 @@ function setupEventHandlers() {
 
     // Unit search
     $('#unit-search').on('input', function() {
-        filterUnits($(this).val());
+        if (!this.value) { $('#available-units .unit-card').css('display',''); }
+        filterUnits(this.value);
     });
 }
 
@@ -724,9 +725,10 @@ function updateAvailableUnitsFilter() {
     $('#available-units .unit-card').each(function() {
         const unitCode = $(this).data('unit-code');
         if (unitsInPlan.has(unitCode)) {
-            $(this).hide();
+            $(this).addClass('hidden');    
         } else {
-            $(this).show();
+            $(this).removeClass('hidden');  
+            $(this).css('display', '');     
         }
     });
 
@@ -739,21 +741,21 @@ function updateSectionHeaders() {
         const $header = $(this);
         let hasVisibleUnits = false;
 
-        // Check if any unit cards after this header are visible
-        $header.nextUntil('.unit-section-header, :last').each(function() {
-            if ($(this).hasClass('unit-card') && $(this).is(':visible')) {
+                $header.nextUntil('.unit-section-header').each(function() {
+            if ($(this).hasClass('unit-card') && !$(this).hasClass('hidden')) {
                 hasVisibleUnits = true;
                 return false; // break
             }
         });
 
         if (hasVisibleUnits) {
-            $header.show();
+            $header.show();   
         } else {
-            $header.hide();
+            $header.hide();  
         }
     });
 }
+
 
 function filterUnits(searchTerm) {
     const term = searchTerm.toLowerCase();
@@ -775,9 +777,9 @@ function filterUnits(searchTerm) {
         const notInPlan = !unitsInPlan.has(actualUnitCode);
 
         if (matchesSearch && notInPlan) {
-            $(this).show().removeClass('hidden');
+            $(this).removeClass('hidden').css('display', '');  // inline 제거
         } else {
-            $(this).hide().addClass('hidden');
+            $(this).addClass('hidden');;
         }
     });
 


### PR DESCRIPTION
## Problem
1) When moving units that create multiple violations, the UI displayed only the newly-added error and hid previously unresolved ones. so now the UI display all errors and warnings which can make users to figure out the total errors in one view.
2) Border color issue: Display green if error-free for intuitive visibility, red if errors exist.

[1-before]
<img width="1261" height="482" alt="before1" src="https://github.com/user-attachments/assets/ad388be4-4a20-4e53-a9b6-18ec4518b820" />

[1-after]
<img width="625" height="227" alt="after1" src="https://github.com/user-attachments/assets/54750281-d8be-44c5-be55-3a199cd5df31" />
<img width="602" height="176" alt="after2" src="https://github.com/user-attachments/assets/9e45d618-ce25-42ec-a733-06cc38223902" />

[2-before]
<img width="696" height="270" alt="before" src="https://github.com/user-attachments/assets/a884ddbe-8346-47b3-99e3-bb12b9c699af" />

[2-after]
<img width="698" height="513" alt="after" src="https://github.com/user-attachments/assets/36ce1360-1bb1-439f-a5d1-766ef776e013" />

